### PR TITLE
introduce Dockerfile to project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Docker image for citeproc-node app
+
+FROM node
+MAINTAINER <PLEASE-INSERT-MAINTAiNER>
+
+# append nodejs binaries TO PATH
+ENV PATH node_modules/.bin:$PATH
+
+# Add source
+COPY . citeproc-js-server
+
+WORKDIR citeproc-js-server
+
+# fetch git submodules
+RUN git submodule init
+RUN git submodule update
+
+RUN npm install
+
+# XML to JSON for optimal performance
+RUN ./xmltojson.py ./csl ./csl-json
+RUN ./xmltojson.py ./csl-locales ./csl-locales-json
+
+# Override configuration to match above paths
+ADD docker/local.json config/local.json
+
+# Expose port
+EXPOSE 8085
+
+# run app
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Also note that the citation server automatically watches the style and locale di
 to automatically use the new versions when they're pulled. This is subject to [platform
 caveats](https://nodejs.org/api/fs.html#fs_caveats)
 
+## Setting up citeproc-js-server using docker
+
+With docker running the citeproc-js-server is easy. Just execute the command
+
+```
+docker run -d -p 8085:8085 <INSERT-OFFICIAL-NAME>
+```
+
 ## Setting up citeproc-js-server
 
 ### Step 1
@@ -49,7 +57,7 @@ If all is well, you will see:
 info Server running at http://127.0.0.1:8085
 ```
 
-### Step 3
+## Test your citeproc-js-server
 
 Now to test the server using the sampledata.json file provided in the
 citeproc-js-server sources. Try posting it to your server, from a separate

--- a/docker/local.json
+++ b/docker/local.json
@@ -1,0 +1,12 @@
+{
+    "port" : 8085,
+    "logLevel" : "info",
+    "localesPath" : "./csl-locales-json",
+    "cslPath" : "./csl-json",
+    "renamedStylesPath": "./csl/renamed-styles.json",
+    "cslDependentPath": "./csl/dependent",
+    "engineCacheSize" : 40,
+    "timings": false,
+    "debug": true,
+    "userAgent": "Zotero Citation Server (https://github.com/zotero/citeproc-js-server)"
+}


### PR DESCRIPTION
This PR addresses issue #33.

If you like, one can automate the docker build via docker hub (I can assist in setting this up).

One needs to add the official image name and the name of the maintainer of this docker image (which I guess should be the citeproc community).

