### PR TITLE
fix: specify encoding utf-8 when opening a file

### DIFF
--- a/xmltojson.py
+++ b/xmltojson.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
                     continue
             
             print("converting " + fullname + " to " + newname)
-            doc = w.makedoc(open(fullname).read())
+            doc = w.makedoc(open(fullname, encoding='utf-8').read())
             obj = w.walktojson(doc)
             open(newname, 'w').write(json.dumps(obj,indent=2))
     elif singleFile:


### PR DESCRIPTION
When a csl file contains gbk characters, for example, [china-national-standard-gb-t-7714-2015-numeric.csl](https://github.com/citation-style-language/styles/blob/39fede595c38cece6f1dcc05ee94163453798c60/china-national-standard-gb-t-7714-2015-numeric.csl#L4), the following error will be reported when the file is opened without specifying the encoding.

```python
PS D:\Code\zotero-cn\citeproc-js-server-master> python .\xmltojson.py ./csl ./csljson
converting ./csl\china-national-standard-gb-t-7714-2015-numeric.csl to ./csljson\china-national-standard-gb-t-7714-2015-numeric.csl
Traceback (most recent call last):
  File "D:\Code\zotero-cn\citeproc-js-server-master\xmltojson.py", line 92, in <module>
    doc = w.makedoc(open(fullname).read())
UnicodeDecodeError: 'gbk' codec can't decode byte 0xaf in position 393: illegal multibyte sequence
```

The script should work fine with this commit modification, for example, [suffix of the year data-part `年`](https://github.com/citation-style-language/styles/blob/39fede595c38cece6f1dcc05ee94163453798c60/china-national-standard-gb-t-7714-2015-numeric.csl#L24) will be converted to `\u5e74` as shown in the figure below.

![image](https://user-images.githubusercontent.com/44738481/183281038-e50a391e-da9a-4dca-b113-b28c44c233d3.png)
