### PR TITLE
obeying cache control for remote styles

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -47,7 +47,8 @@ var jsdom = require('jsdom');
 const { JSDOM } = jsdom;
 var log = require('npmlog');
 var path = require('path');
-
+const CachePolicy = require('http-cache-semantics');
+var cache = {};
 /**
  * CslLoader constructor. Runs scanStyles synchronously on instantiation.
  * @param {Object} config config object. Should have at least 'cslPath' if not
@@ -296,6 +297,15 @@ exports.CslLoader.prototype.fetchIndependentStyle = function(styleUrlObj){
             styleUrlObj.headers = {
                 'User-Agent': cslLoader.config.userAgent
             };
+            let cached = cache[styleUrlObj.href];
+            const requestHeaders = {
+                'user-agent': cslLoader.config.userAgent,
+                'host': styleUrlObj.host || ""
+            };
+            if (cached && cached.policy.satisfiesWithoutRevalidation({ headers: requestHeaders })) { 
+                resolve(cached.body);
+                return;
+            }
             let req = httpGetter.request(styleUrlObj, function(response) {
                 if(response.statusCode != 200){
                     log.error("non-200 status: " + response.statusCode);
@@ -310,6 +320,14 @@ exports.CslLoader.prototype.fetchIndependentStyle = function(styleUrlObj){
                     cslXml += chunk;
                 });
                 response.on('end', function(){
+                    response.req.headers = response.req.getHeaders();
+                    let policy = new CachePolicy(response.req, response);
+                    if (policy.storable()) {
+                        cache[styleUrlObj.href] = {
+                          policy: policy,
+                          body: cslXml,
+                        };
+                      }
                     //log.info(cslXml);
                     resolve(cslXml);
                 });

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -286,7 +286,6 @@ exports.CslLoader.prototype.fetchIndependentStyle = function(styleUrlObj){
             //log.error("CslLoader.fetchIndependentStyle", "non zotero style requested");
             //throw new Error("non-Zotero styles are not supported at this time");
             let cslXml = '';
-            log.info("Requesting style url: " + url.format(styleUrlObj));
             let httpGetter;
             if(styleUrlObj.protocol == 'https:'){
                 httpGetter = https;
@@ -303,9 +302,11 @@ exports.CslLoader.prototype.fetchIndependentStyle = function(styleUrlObj){
                 'host': styleUrlObj.host || ""
             };
             if (cached && cached.policy.satisfiesWithoutRevalidation({ headers: requestHeaders })) { 
+                log.info("Using cached style for " + url.format(styleUrlObj));
                 resolve(cached.body);
                 return;
             }
+            log.info("Fetching style from " + url.format(styleUrlObj));
             let req = httpGetter.request(styleUrlObj, function(response) {
                 if(response.statusCode != 200){
                     log.error("non-200 status: " + response.statusCode);

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   },
   "dependencies": {
     "config": "^3.0.0",
+    "http-cache-semantics": "^4.1.1",
     "jsdom": "^13.0.0",
     "npmlog": "^4.1.2",
     "optimist": ">=0.3.1",
     "underscore": "^1.9.1"
   },
-  "devDependencies": {},
   "scripts": {
     "start": "node lib/citeServer.js",
     "test": "node test/testallstyles.js"


### PR DESCRIPTION
`http-cache-semantics` handles policies that determine if request is cached and for how long per [#32](https://github.com/zotero/citeproc-js-server/issues/32)